### PR TITLE
(fix): Change the render function dectory to use the right symbol

### DIFF
--- a/src/firefly.h
+++ b/src/firefly.h
@@ -14,7 +14,7 @@
 #define UPDATE __attribute__((export_name("update")))
 
 /// @brief Mark an "render" callback function.
-#define RENDER __attribute__((export_name("update")))
+#define RENDER __attribute__((export_name("render")))
 
 /// @brief Mark a "cheat" callback function.
 #define CHEAT __attribute__((export_name("cheat")))


### PR DESCRIPTION
Currently Compiling with C will crash on loading the application because update is defined twice.